### PR TITLE
Import partner event data with error handling

### DIFF
--- a/mondelibertin_event_publisher.html
+++ b/mondelibertin_event_publisher.html
@@ -44,6 +44,10 @@ function parsePartnerSite(url, doc){
   if(hostname.includes('partner-site.com')){
     return parsePartnerSiteExample(doc);
   }
+  // ⇩ Nouveau domaine pris en charge
+  if(hostname.includes('wemagnifique.fr')){
+    return parseWeMagnifique(doc);
+  }
   throw new Error('Aucun parseur disponible pour ce domaine ('+hostname+').');
 }
 
@@ -59,11 +63,25 @@ function parsePartnerSiteExample(doc){
   return {title, description, startDate, endDate, location, imageUrl, category};
 }
 
+// === Parseur pour https://wemagnifique.fr ===
+function parseWeMagnifique(doc){
+  const title = doc.querySelector('h1.page-title, h1.mec-single-title')?.textContent.trim();
+  const description = doc.querySelector('.mec-event-content')?.innerText.trim();
+  const startDate = doc.querySelector('.mec-start-date-label')?.textContent.trim();
+  const endDate = doc.querySelector('.mec-end-date-label')?.textContent.trim();
+  const location = doc.querySelector('.mec-address')?.innerText.trim();
+  const imageUrl = doc.querySelector('.mec-events-event-image img')?.src;
+  const category = 'Soirée libertine';
+  return {title, description, startDate, endDate, location, imageUrl, category};
+}
+
 /* =====================
  * Helper: GET HTML document via fetch
  * ===================== */
 async function fetchDocument(url){
-  const res = await fetch(url, {credentials:'include'});
+  // Utilisation d'un proxy CORS public pour contourner les restrictions du navigateur.
+  const proxiedUrl = 'https://api.allorigins.win/raw?url=' + encodeURIComponent(url);
+  const res = await fetch(proxiedUrl);
   if(!res.ok) throw new Error('Impossible de récupérer la page partenaire ('+res.status+').');
   const html = await res.text();
   return new DOMParser().parseFromString(html, 'text/html');


### PR DESCRIPTION
Add wemagnifique.fr parser and bypass CORS for partner site imports to fix 'Failed to fetch' error.

The `wemagnifique.fr` site blocks cross-origin requests, causing a 'Failed to fetch' error. This PR routes all `fetchDocument` requests through the AllOrigins public proxy to bypass this restriction and adds a specific parser for `wemagnifique.fr` to extract event details.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b7871c5-ba46-4c48-b1b6-91601054494f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b7871c5-ba46-4c48-b1b6-91601054494f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

